### PR TITLE
Version 0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.3.0 2024-01-21
+
+- Breaking: Removes async-trait dependency
+- Breaking: Redis backend now uses BITFIELD to store counts
+
 ## 0.2.2 2022-04-19
 
 - Improve documentation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## 0.3.0 2024-01-21
 
-- Breaking: Removes async-trait dependency
-- Breaking: Redis backend now uses BITFIELD to store counts
+- Breaking: Removes async-trait dependency.
+- Breaking: Redis backend now uses BITFIELD to store counts.
+- Breaking: Backend return type is now a `Decision` enum instead of a `bool`.
 
 ## 0.2.2 2022-04-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ actix-web = { version = "4", default-features = false, features = ["macros"] }
 dashmap = { version = "5.4.0", optional = true }
 futures = "0.3.28"
 log = "0.4.19"
-redis = { version = "0.23.0", default-features = false, features = ["tokio-comp", "aio", "connection-manager"], optional = true }
+redis = { version = "0.24.0", default-features = false, features = ["tokio-comp", "aio", "connection-manager"], optional = true }
 thiserror = "1.0.40"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-extensible-rate-limit"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Rate limiting middleware for actix-web"
@@ -9,11 +9,9 @@ homepage = "https://github.com/jacob-pro/actix-extensible-rate-limit"
 
 [dependencies]
 actix-web = { version = "4", default-features = false, features = ["macros"] }
-async-trait = "0.1.68"
 dashmap = { version = "5.4.0", optional = true }
 futures = "0.3.28"
 log = "0.4.19"
-once_cell = "1.17.1"
 redis = { version = "0.23.0", default-features = false, features = ["tokio-comp", "aio", "connection-manager"], optional = true }
 thiserror = "1.0.40"
 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,25 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 ```
+
+Try it out:
+
+```
+$ curl -v http://127.0.0.1:8080
+*   Trying 127.0.0.1:8080...
+* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+> GET / HTTP/1.1
+> Host: 127.0.0.1:8080
+> User-Agent: curl/7.83.1
+> Accept: */*
+>
+* Mark bundle as not supporting multiuse
+< HTTP/1.1 404 Not Found
+< content-length: 0
+< x-ratelimit-limit: 5
+< x-ratelimit-reset: 60
+< x-ratelimit-remaining: 4
+< date: Sun, 21 Jan 2024 16:52:27 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+```

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -9,22 +9,41 @@ pub mod memory;
 pub mod redis;
 
 pub use input_builder::{SimpleInputFunctionBuilder, SimpleInputFuture};
+use std::future::Future;
 
 use crate::HeaderCompatibleOutput;
 use actix_web::rt::time::Instant;
-use async_trait::async_trait;
 use std::time::Duration;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Decision {
+    Allowed,
+    Denied,
+}
+
+impl Decision {
+    pub fn from_allowed(allowed: bool) -> Self {
+        if allowed {
+            Self::Allowed
+        } else {
+            Self::Denied
+        }
+    }
+
+    pub fn is_allowed(self) -> bool {
+        self == Self::Allowed
+    }
+
+    pub fn is_denied(self) -> bool {
+        matches!(self, Self::Denied)
+    }
+}
+
 /// Describes an implementation of a rate limiting store and algorithm.
-///
-/// To implement your own rate limiting backend it is recommended to use
-/// [async_trait](https://github.com/dtolnay/async-trait), and add the `#[async_trait(?Send)]`
-/// attribute onto your trait implementation.
 ///
 /// A Backend is required to implement [Clone], usually this means wrapping your data store within
 /// an [Arc](std::sync::Arc), although many connection pools already do so internally; there is no
 /// need to wrap it twice.
-#[async_trait(?Send)]
 pub trait Backend<I: 'static = SimpleInput>: Clone {
     type Output;
     type RollbackToken;
@@ -38,10 +57,10 @@ pub trait Backend<I: 'static = SimpleInput>: Clone {
     /// Returns a boolean of whether to allow or deny the request, arbitrary output that can be used
     /// to transform the allowed and denied responses, and a token to allow the rate limit counter
     /// to be rolled back in certain conditions.
-    async fn request(
+    fn request(
         &self,
         input: I,
-    ) -> Result<(bool, Self::Output, Self::RollbackToken), Self::Error>;
+    ) -> impl Future<Output = Result<(Decision, Self::Output, Self::RollbackToken), Self::Error>>;
 
     /// Under certain conditions we may not want to rollback the request operation.
     ///
@@ -55,7 +74,8 @@ pub trait Backend<I: 'static = SimpleInput>: Clone {
     /// # Arguments
     ///
     /// * `token`: The token returned from the initial call to [Backend::request()].
-    async fn rollback(&self, token: Self::RollbackToken) -> Result<(), Self::Error>;
+    fn rollback(&self, token: Self::RollbackToken)
+        -> impl Future<Output = Result<(), Self::Error>>;
 }
 
 /// A default [Backend] Input structure.
@@ -85,12 +105,11 @@ pub struct SimpleOutput {
 }
 
 /// Additional functions for a [Backend] that uses [SimpleInput] and [SimpleOutput].
-#[async_trait(?Send)]
 pub trait SimpleBackend: Backend<SimpleInput, Output = SimpleOutput> {
     /// Removes the bucket for a given rate limit key.
     ///
     /// Intended to be used to reset a key before changing the interval.
-    async fn remove_key(&self, key: &str) -> Result<(), Self::Error>;
+    fn remove_key(&self, key: &str) -> impl Future<Output = Result<(), Self::Error>>;
 }
 
 impl HeaderCompatibleOutput for SimpleOutput {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -31,7 +31,7 @@ impl Decision {
     }
 
     pub fn is_allowed(self) -> bool {
-        self == Self::Allowed
+        matches!(self, Self::Allowed)
     }
 
     pub fn is_denied(self) -> bool {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -141,8 +141,8 @@ where
 
             let (output, rollback) = match backend.request(input).await {
                 // Able to successfully query rate limiter backend
-                Ok((allow, output, rollback)) => {
-                    if !allow {
+                Ok((decision, output, rollback)) => {
+                    if decision.is_denied() {
                         let response: HttpResponse = (denied_response)(&output);
                         return Ok(req.into_response(response).map_into_right_body());
                     }


### PR DESCRIPTION
Two main changes:
- Removes `async-trait` crate now that it is supported by Rust itself
- Changes Redis backend to use the `BITFIELD` command to store counts, this way we can safely decrement saturating at 0 without a transaction (use unsigned integers).