### PR TITLE
Update redis vesion to 0.29.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ actix-web = { version = "4", default-features = false, features = ["macros"] }
 dashmap = { version = "6.0", optional = true }
 futures = "0.3.28"
 log = "0.4.19"
-redis = { version = "0.26", default-features = false, features = [
+redis = { version = "0.29.1", default-features = false, features = [
   "tokio-comp",
   "aio",
   "connection-manager",

--- a/src/backend/redis.rs
+++ b/src/backend/redis.rs
@@ -165,7 +165,7 @@ impl Backend<SimpleInput> for RedisBackend {
             .arg("NX")
             .ignore();
 
-        pipe.query_async(&mut con).await?;
+        let () = pipe.query_async(&mut con).await?;
 
         Ok(())
     }
@@ -177,7 +177,7 @@ impl SimpleBackend for RedisBackend {
     async fn remove_key(&self, key: &str) -> Result<(), Self::Error> {
         let key = self.make_key(key);
         let mut con = self.connection.clone();
-        con.del(key.as_ref()).await?;
+        let () = con.del(key.as_ref()).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Hi, thanks for creating this lib :) I'm using it in my rust playground app and since the lib uses an old version of redis I had to downgrade the version in my app too

The `let () = conn.action` changes are done to avoid warnings that show up since version 0.28