### PR TITLE
Generic backend

### DIFF
--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -4,15 +4,15 @@ use actix_web::rt::time::Instant;
 use dashmap::DashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::Duration;use std::hash::Hash;
 
 pub const DEFAULT_GC_INTERVAL_SECONDS: u64 = 60 * 10;
 
 /// A Fixed Window rate limiter [Backend] that uses [Dashmap](dashmap::DashMap) to store keys
 /// in memory.
 #[derive(Clone)]
-pub struct InMemoryBackend {
-    map: Arc<DashMap<String, Value>>,
+pub struct InMemoryBackend<T: Clone = String> {
+    map: Arc<DashMap<T, Value>>,
     gc_handle: Option<Arc<JoinHandle<()>>>,
 }
 
@@ -21,14 +21,14 @@ struct Value {
     count: u64,
 }
 
-impl InMemoryBackend {
+impl <T:Clone + Eq+ Hash + 'static>InMemoryBackend<T> {
     pub fn builder() -> Builder {
         Builder {
             gc_interval: Some(Duration::from_secs(DEFAULT_GC_INTERVAL_SECONDS)),
         }
     }
 
-    fn garbage_collector(map: Arc<DashMap<String, Value>>, interval: Duration) -> JoinHandle<()> {
+    fn garbage_collector(map: Arc<DashMap<T, Value>>, interval: Duration) -> JoinHandle<()> {
         assert!(
             interval.as_secs_f64() > 0f64,
             "GC interval must be non-zero"
@@ -58,8 +58,8 @@ impl Builder {
         self
     }
 
-    pub fn build(self) -> InMemoryBackend {
-        let map = Arc::new(DashMap::<String, Value>::new());
+    pub fn build<T:Clone + Eq + Hash + 'static>(self) -> InMemoryBackend<T> {
+        let map = Arc::new(DashMap::<T, Value>::new());
         let gc_handle = self.gc_interval.map(|gc_interval| {
             Arc::new(InMemoryBackend::garbage_collector(map.clone(), gc_interval))
         });
@@ -67,9 +67,9 @@ impl Builder {
     }
 }
 
-impl<I:Input> Backend<I> for InMemoryBackend {
+impl<I:Input + 'static> Backend<I> for InMemoryBackend<I::Key> where <I as Input>::Key: Eq + Hash {
     type Output = SimpleOutput;
-    type RollbackToken = String;
+    type RollbackToken = I::Key;
     type Error = Infallible;
 
     async fn request(
@@ -124,7 +124,7 @@ impl SimpleBackend for InMemoryBackend {
     }
 }
 
-impl Drop for InMemoryBackend {
+impl<I:Clone> Drop for InMemoryBackend<I> {
     fn drop(&mut self) {
         if let Some(handle) = &self.gc_handle {
             handle.abort();

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -1,4 +1,4 @@
-use crate::backend::{Backend, Decision, SimpleBackend, SimpleInput, SimpleOutput};
+use crate::backend::{Backend, Decision, Input, SimpleBackend, SimpleOutput};
 use actix_web::rt::task::JoinHandle;
 use actix_web::rt::time::Instant;
 use dashmap::DashMap;
@@ -67,22 +67,22 @@ impl Builder {
     }
 }
 
-impl Backend<SimpleInput> for InMemoryBackend {
+impl<I:Input> Backend<I> for InMemoryBackend {
     type Output = SimpleOutput;
     type RollbackToken = String;
     type Error = Infallible;
 
     async fn request(
         &self,
-        input: SimpleInput,
+        input: I,
     ) -> Result<(Decision, Self::Output, Self::RollbackToken), Self::Error> {
         let now = Instant::now();
         let mut count = 1;
         let mut expiry = now
-            .checked_add(input.interval)
+            .checked_add(input.interval())
             .expect("Interval unexpectedly large");
         self.map
-            .entry(input.key.clone())
+            .entry(input.key().clone())
             .and_modify(|v| {
                 // If this bucket hasn't yet expired, increment and extract the count/expiry
                 if v.ttl > now {
@@ -100,13 +100,13 @@ impl Backend<SimpleInput> for InMemoryBackend {
                 ttl: expiry,
                 count,
             });
-        let allow = count <= input.max_requests;
+        let allow = count <= input.max_requests();
         let output = SimpleOutput {
-            limit: input.max_requests,
-            remaining: input.max_requests.saturating_sub(count),
+            limit: input.max_requests(),
+            remaining: input.max_requests().saturating_sub(count),
             reset: expiry,
         };
-        Ok((Decision::from_allowed(allow), output, input.key))
+        Ok((Decision::from_allowed(allow), output, input.key()))
     }
 
     async fn rollback(&self, token: Self::RollbackToken) -> Result<(), Self::Error> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -44,7 +44,7 @@ impl Decision {
 /// A Backend is required to implement [Clone], usually this means wrapping your data store within
 /// an [Arc](std::sync::Arc), although many connection pools already do so internally; there is no
 /// need to wrap it twice.
-pub trait Backend<I: Input>: Clone {
+pub trait Backend<I: Input + 'static = SimpleInput>: Clone {
     type Output;
     type RollbackToken;
     type Error;
@@ -92,12 +92,15 @@ pub struct SimpleInput {
 }
 
 pub trait Input {
+    type Key: Clone;
     fn interval(&self) -> Duration {todo!()}
     fn max_requests(&self) -> u64 {todo!()}
-    fn key(&self) -> String {todo!()}
+    fn key(&self) -> Self::Key {todo!()}
 }
 
-impl Input for SimpleInput {}
+impl Input for SimpleInput {
+    type Key= String;
+}
 
 /// A default [Backend::Output] structure.
 ///

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -44,7 +44,7 @@ impl Decision {
 /// A Backend is required to implement [Clone], usually this means wrapping your data store within
 /// an [Arc](std::sync::Arc), although many connection pools already do so internally; there is no
 /// need to wrap it twice.
-pub trait Backend<I: 'static = SimpleInput>: Clone {
+pub trait Backend<I: Input>: Clone {
     type Output;
     type RollbackToken;
     type Error;
@@ -90,6 +90,14 @@ pub struct SimpleInput {
     /// The rate limit key to be used for this request.
     pub key: String,
 }
+
+pub trait Input {
+    fn interval(&self) -> Duration {todo!()}
+    fn max_requests(&self) -> u64 {todo!()}
+    fn key(&self) -> String {todo!()}
+}
+
+impl Input for SimpleInput {}
 
 /// A default [Backend::Output] structure.
 ///

--- a/src/middleware/builder.rs
+++ b/src/middleware/builder.rs
@@ -1,4 +1,4 @@
-use crate::backend::Backend;
+use crate::backend::{Backend, Input};
 use crate::middleware::{AllowedTransformation, DeniedResponse, RateLimiter, RollbackCondition};
 use actix_web::dev::ServiceRequest;
 use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue, RETRY_AFTER};
@@ -26,7 +26,7 @@ pub struct RateLimiterBuilder<BE, BO, F> {
 impl<BE, BI, BO, F, O> RateLimiterBuilder<BE, BO, F>
 where
     BE: Backend<BI, Output = BO> + 'static,
-    BI: 'static,
+    BI: Input + 'static,
     F: Fn(&ServiceRequest) -> O,
     O: Future<Output = Result<BI, actix_web::Error>>,
 {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -2,7 +2,7 @@ pub mod builder;
 #[cfg(test)]
 mod tests;
 
-use crate::backend::Backend;
+use crate::backend::{Backend, Input};
 use actix_web::body::EitherBody;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::header::HeaderMap;
@@ -30,7 +30,7 @@ pub struct RateLimiter<BA, BO, F> {
 impl<BA, BI, BO, F, O> Clone for RateLimiter<BA, BO, F>
 where
     BA: Backend<BI> + 'static,
-    BI: 'static,
+    BI: Input + 'static,
     F: Fn(&ServiceRequest) -> O + 'static,
     O: Future<Output = Result<BI, actix_web::Error>>,
 {
@@ -49,7 +49,7 @@ where
 impl<BA, BI, BO, F, O> RateLimiter<BA, BO, F>
 where
     BA: Backend<BI, Output = BO> + 'static,
-    BI: 'static,
+    BI: Input + 'static,
     F: Fn(&ServiceRequest) -> O + 'static,
     O: Future<Output = Result<BI, actix_web::Error>>,
 {
@@ -68,7 +68,7 @@ where
     S::Future: 'static,
     B: 'static,
     BA: Backend<BI, Output = BO, Error = BE> + 'static,
-    BI: 'static,
+    BI: Input +'static,
     BO: 'static,
     BE: Into<actix_web::Error> + std::fmt::Display + 'static,
     F: Fn(&ServiceRequest) -> O + 'static,
@@ -109,7 +109,7 @@ where
     S::Future: 'static,
     B: 'static,
     BA: Backend<BI, Output = BO, Error = BE> + 'static,
-    BI: 'static,
+    BI: Input +'static,
     BO: 'static,
     BE: Into<actix_web::Error> + std::fmt::Display + 'static,
     F: Fn(&ServiceRequest) -> O + 'static,


### PR DESCRIPTION
With these changes we should be able to use the library without having to copy-paste all of `InMemoryBackend` unchanged. Work in progress, something is still wrong with the generics.